### PR TITLE
`antialiasing` typo fixed

### DIFF
--- a/lib/src/rive.dart
+++ b/lib/src/rive.dart
@@ -34,7 +34,7 @@ class Rive extends LeafRenderObjectWidget {
   /// Alignment for the rendering artboard
   final Alignment alignment;
 
-  /// Enables/disables anitalising
+  /// Enables/disables antialiasing
   final bool antialiasing;
 
   const Rive({


### PR DESCRIPTION
There is a typo on the `antialiasing` description.